### PR TITLE
Fix the genre to display correctly

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -4,10 +4,10 @@ import dayjs from "dayjs";
 const formatRatings = (movieList) => {
   return movieList.map((movie) => {
     const currentMovie = {...movie};
-    currentMovie.average_rating = Math.round(movie.average_rating)
+    currentMovie.average_rating = Math.round(movie.average_rating);
     return currentMovie
-  })
-}
+  });
+};
 
 const formatMovieInfo = (movie) => {
   const singleMovie = movie;
@@ -16,8 +16,9 @@ const formatMovieInfo = (movie) => {
   singleMovie.runtime = `${hours} Hours ${minutes} Minutes`;
   singleMovie.release_date = dayjs(singleMovie.release_date).format('MMM DD, YYYY');
   singleMovie.average_rating = Math.round(movie.average_rating);
+  singleMovie.genres = singleMovie.genres.join("/");
 
   return singleMovie;
-}
+};
 
 export {formatRatings, formatMovieInfo}


### PR DESCRIPTION
## Describe your changes:
[//]: <> (Which files were changed? What changes were made?)

utilites.js
I added a .join to the formatMovieInfo function to display the genres with a "/" in between (ex Action/Drama) as I thought it looked better than a ",". If you prefer one over the other we can change it!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested the functionality of any new or updated features in the browser, if applicable
- [x] I have added a "Reviewer" to review & merge
- [] If applicable, my code passes all tests


If issue found, describe and refernces user story/projectboard issue
